### PR TITLE
Solution15: Use Regular Expressions to Test a String

### DIFF
--- a/tests/1_unit-tests.js
+++ b/tests/1_unit-tests.js
@@ -117,8 +117,8 @@ suite('Unit Tests', function () {
     // #15
     test('#match, #notMatch', function () {
       const regex = /^#\sname\:\s[\w\s]+,\sage\:\s\d+\s?$/;
-      assert.fail(formatPeople('John Doe', 35), regex);
-      assert.fail(formatPeople('Paul Smith III', 'twenty-four'), regex);
+      assert.match(formatPeople('John Doe', 35), regex);
+      assert.notMatch(formatPeople('Paul Smith III', 'twenty-four'), regex);
     });
   });
 


### PR DESCRIPTION
Within tests/1_unit-tests.js under the test labeled #15 in the Strings suite, change each assert to either assert.match or assert.notMatch to make the test pass (should evaluate to true). Do not alter the arguments passed to the asserts.